### PR TITLE
Export address

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export * from './allowanceTransfer'
 export * from './signatureTransfer'
 export * from './providers'
+export * from './utils/constants'

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,0 +1,8 @@
+export const PERMIT2_ADDRESS = (chainId: number) => {
+  switch (chainId) {
+    case 1:
+      return '0x6fEe9BeC3B3fc8f9DA5740f0efc6BbE6966cd6A6'
+    default:
+      throw new Error(`Permit2 not deployed on chain ${chainId}`)
+  }
+}


### PR DESCRIPTION
Think we should move to a model where version of each SDK are tied to particular contracts. Less important for P2 since that will hopefully never change, but for UR as we upgrade it will be confusing which SDK versions support which contracts